### PR TITLE
Pass data to action to do something before it imports

### DIFF
--- a/includes/import.php
+++ b/includes/import.php
@@ -116,7 +116,8 @@ function wie_import_data( $data ) {
 	}
 
 	// Hook before import
-	do_action( 'wie_before_import', $data );
+	do_action( 'wie_before_import' );
+	$data = apply_filters( 'wie_import_data', $data );
 
 	// Get all available widgets site supports
 	$available_widgets = wie_available_widgets();


### PR DESCRIPTION
Pass import data to `wie_before_import` action so we can do something with it before widgets are imported
